### PR TITLE
Fix ArrayBuffer in WebWorker

### DIFF
--- a/src/sha512.js
+++ b/src/sha512.js
@@ -184,7 +184,7 @@
       return;
     }
     var notString = typeof(message) !== 'string';
-    if (notString && ARRAY_BUFFER && message instanceof root.ArrayBuffer) {
+    if (notString && ARRAY_BUFFER && message instanceof ArrayBuffer) {
       message = new Uint8Array(message);
     }
     var code, index = 0, i, length = message.length || 0, blocks = this.blocks;


### PR DESCRIPTION
ARRAY_BUFFER constant was set using global ArrayBuffer, but here instance checking is made against root.ArrayBuffer.
This breaks WebWorker which has native ArrayBuffer, but no window.
With this simple fix, I am successfully using it in WebWorker.

Please tell me if you are interested in a pull request to make injecting into global object explicit and support ES6 modules.