### PR TITLE
Fix NodeJS check for electron renderer

### DIFF
--- a/src/sha512.js
+++ b/src/sha512.js
@@ -18,7 +18,7 @@
     WINDOW = false;
   }
   var WEB_WORKER = !WINDOW && typeof self === 'object';
-  var NODE_JS = !root.JS_SHA512_NO_NODE_JS && typeof process === 'object' && process.versions && process.versions.node;
+  var NODE_JS = !root.JS_SHA512_NO_NODE_JS && typeof process === 'object' && process.versions && process.versions.node && process.type != 'renderer';
   if (NODE_JS) {
     root = global;
   } else if (WEB_WORKER) {


### PR DESCRIPTION
The same NODE_JS detection issue was fixed in js-sha256 (emn178/js-sha256#49) but not here. The check returns true in an Electron renderer started with `nodeIntegrationInWorker: true`, because `process` exists in that context. Electron sets `process.type` to `"renderer"` there, so this adds the matching `process.type != 'renderer'` guard. With it the renderer takes the pure-JS path instead of trying to wrap Node's `crypto`.

The change is the same one-line guard already merged in js-sha256. `mocha tests/node-test.js` still passes (8360 tests): under normal Node `process.type` is undefined, so `NODE_JS` stays true and behavior there is unchanged.
